### PR TITLE
fix: change default value of context input to false in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -201,7 +201,7 @@ inputs:
     description:
       If true, it will also provide the file content as context when review or
       summary.
-    default: "true"
+    default: "false"
   language:
     required: false
     description: ISO code for the response language


### PR DESCRIPTION
This pull request includes a small but important change to the `action.yml` file. The change modifies the default value of the `inputs:` section to improve the handling of file content as context.

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L204-R204): Changed the default value of the `inputs:` section's `description` field from `"true"` to `"false"`.